### PR TITLE
Add 1password-cli

### DIFF
--- a/macOS/brew/Brewfile
+++ b/macOS/brew/Brewfile
@@ -135,6 +135,7 @@ cask 'vlc'
 # cask 'pencil'
 
 cask '1password'
+brew '1password-cli'
 
 # sshfs
 # relies on kernel extension which will be blocked


### PR DESCRIPTION
Related to https://github.com/AlanGreene/starter/issues/59

This can be used in scripts (including Automator) to read passwords or other data from 1password vaults, e.g.:
`op read op://<vault>/<item>/<field>`

There's some additional config required to enable this, but having it installed is the first step. Will investigate automating the other config separately.